### PR TITLE
cuda: enable fused top1 logits under VOX_CUDA_FAST

### DIFF
--- a/PR_NOTES_CUDA_WSL2.md
+++ b/PR_NOTES_CUDA_WSL2.md
@@ -25,7 +25,6 @@ The CUDA runtime uses the CUDA Driver API (`libcuda`) and embeds a CUBIN for cus
   - Optional host page registration for hot weight ranges: `VOX_CUDA_HOSTREG_GIB=<GiB>` (0 disables; best-effort).
   - Optional prefetch at model load: `VOX_CUDA_PREFETCH=1` (shifts weight uploads out of the first transcription call).
 - Encoder full path:
-  - CPU conv stem remains on CPU by default (small); optional GPU conv stem is available (opt-in).
   - Transformer layers + adapter run on GPU; intermediates stay on device.
 - Decoder full path:
   - Device-side KV cache (FP16 by default) and device-only intermediates.
@@ -36,6 +35,7 @@ The CUDA runtime uses the CUDA Driver API (`libcuda`) and embeds a CUBIN for cus
   - Optional CUDA Graph capture for the single-token decoder step (reduces CPU launch overhead; opt-in).
   - Optional device RoPE freqs generation for CUDA Graph mode (reduces CPU overhead per step; opt-in).
   - Optional logits copy: if `logits==NULL`, logits stay on GPU and only the best token id is copied back.
+  - Optional fused top1-only logits projection (enabled by `VOX_CUDA_FAST=1`): avoids materializing the full-vocab logits buffer when only the best token id is needed.
   - Prefill is attempted on GPU (seq_len > 1) and falls back to the CPU prefill implementation if unsupported/disabled.
 
 ## Build

--- a/README.md
+++ b/README.md
@@ -408,6 +408,9 @@ Fast CUDA config (best-effort, can be overridden by per-feature env vars):
 VOX_CUDA_FAST=1 ./voxtral -d voxtral-model -i samples/test_speech.wav
 ```
 
+Notes:
+- `VOX_CUDA_FAST=1` enables a fused top1-only logits path by default when alternatives are disabled (`--alt` not used). Disable it with `VOX_DISABLE_CUDA_LOGITS_FUSED=1` if you want to benchmark the baseline logits+argmax path.
+
 To run the extra CUDA benchmark variants (graphs/v3/merged/etc):
 
 ```bash

--- a/voxtral_cuda.c
+++ b/voxtral_cuda.c
@@ -265,13 +265,14 @@ static int attn_v4_enabled(void) {
 
 static int logits_fused_enabled(void) {
     /* Opt-in: fused top1-only logits projection (avoids materializing logits[]).
-     * Default off until validated broadly. */
+     * Default on under VOX_CUDA_FAST (can be disabled explicitly). */
     static int cached = -1;
     if (cached != -1) return cached;
     const char *disable = getenv("VOX_DISABLE_CUDA_LOGITS_FUSED");
     if (disable && disable[0] && disable[0] != '0') { cached = 0; return cached; }
     const char *env = getenv("VOX_CUDA_LOGITS_FUSED");
-    cached = (env && env[0] && env[0] != '0');
+    if (env) { cached = (env[0] && env[0] != '0'); return cached; }
+    cached = cuda_fast_enabled();
     return cached;
 }
 


### PR DESCRIPTION
This PR flips the default for the existing fused top1-only logits path so it is enabled automatically under `VOX_CUDA_FAST=1` (still disable-able via `VOX_DISABLE_CUDA_LOGITS_FUSED=1`).

## Why
- In the common path (no `--alt`), we only need the best token id, not the full `[vocab]` logits buffer.
- The fused kernel avoids materializing logits and can reduce per-step decoder cost on some GPUs.

## Notes
- No behavior change when alternatives are enabled (`--alt`), since we still need full logits.
- The opt-in knob remains: `VOX_CUDA_LOGITS_FUSED=0/1`.
- `VOX_DISABLE_CUDA_LOGITS_FUSED=1` forces the baseline logits+argmax path even under FAST.

## Validation
- `make cuda`
- `./scripts/validate_cuda.sh voxtral-model samples/test_speech.wav`
- `./scripts/accuracy_regression.sh voxtral-model samples/test_speech.wav 0.005`
- `./runtest.sh`

## Bench (WSL2 RTX 3080 Ti)
These are "wall transcribe" numbers (excluding model load), from `VOX_PRINT_TIMINGS=1`.

- `samples/test_speech.wav` (3.642s): wall `2526 ms` (xRT `1.44x`), decoder `10.4 ms/step`
- `/tmp/vox_iad.wav` (180.021s): wall `34141 ms` (xRT `5.27x`), decoder `13.4 ms/step`
