### PR TITLE
CUDA perf: cuBLASLt autotune for M=1 BF16 GEMMs

### DIFF
--- a/PR_NOTES_CUDA_WSL2.md
+++ b/PR_NOTES_CUDA_WSL2.md
@@ -14,6 +14,7 @@ The CUDA runtime uses the CUDA Driver API (`libcuda`) and embeds a CUBIN for cus
 - CUDA runtime init uses:
   - `cuInit`, primary context, non-blocking stream
   - cuBLAS + (optional) cuBLASLt for small `M=1` GEMMs
+  - Optional cuBLASLt autotune for `M=1` decoder GEMMs (enabled by `VOX_CUDA_FAST=1`; disable with `VOX_DISABLE_CUBLASLT_AUTOTUNE=1`)
 - Custom CUDA kernels:
   - Built via `nvcc -cubin` and embedded as a C header (no PTX JIT at runtime).
   - Implements RMSNorm, RoPE, BF16/FP16 casts, SwiGLU/GELU, downsample concat, argmax, etc.

--- a/README.md
+++ b/README.md
@@ -410,6 +410,7 @@ VOX_CUDA_FAST=1 ./voxtral -d voxtral-model -i samples/test_speech.wav
 
 Notes:
 - `VOX_CUDA_FAST=1` enables a fused top1-only logits path by default when alternatives are disabled (`--alt` not used). Disable it with `VOX_DISABLE_CUDA_LOGITS_FUSED=1` if you want to benchmark the baseline logits+argmax path.
+- `VOX_CUDA_FAST=1` also enables cuBLASLt autotune for the `M=1` decoder GEMMs (best-effort). Disable it with `VOX_DISABLE_CUBLASLT_AUTOTUNE=1`.
 
 To run the extra CUDA benchmark variants (graphs/v3/merged/etc):
 


### PR DESCRIPTION
This adds a best-effort cuBLASLt autotuner for repeated decoder GEMMs where `M=1` (typical for decode steps).

- At first use, query top-N heuristics (default 8) under the current workspace cap, time each with CUDA events, and cache the fastest algo+workspace.
- Graph-safe: autotune is skipped during CUDA Graph capture, and decoder graph prep runs the autotune pass before capture so the graph sees stable cached algos/workspace.
- Uses a scratch output buffer so tuning never clobbers real `C` (important for `beta=1` residual-add GEMMs).

Env knobs:
- `VOX_CUDA_FAST=1` enables autotune by default
- Disable: `VOX_DISABLE_CUBLASLT_AUTOTUNE=1`
- Override: `VOX_CUDA_CUBLASLT_AUTOTUNE=0/1`
- Optional: `VOX_CUDA_CUBLASLT_AUTOTUNE_TOP` (1..32, default 8)
- Optional: `VOX_CUDA_CUBLASLT_AUTOTUNE_ITERS` (1..200, default 25, auto-capped for large N)

Benchmarks (RTX 3080 Ti 12GB, WSL2, CUDA 13.1; `VOX_PRINT_TIMINGS=1` transcribe timings exclude model load):

- `/tmp/vox_iad.wav` (180.021s)
  - autotune ON: transcribe 33.701s => 5.34xRT; decoder 13.1 ms/step
  - autotune OFF: transcribe 34.819s => 5.17xRT; decoder 13.7 ms/step
  - delta: -3.2% wall, -4.4% ms/step

- `samples/test_speech.wav` (3.642s)
  - autotune ON: transcribe 2.637s => 1.38xRT; decoder 10.1 ms/step
  - autotune OFF: transcribe 2.541s => 1.43xRT; decoder 10.6 ms/step
  - note: for one-off short runs, autotune overhead can slightly regress wall. Disable if you care about minimal startup latency.

Fixes #13
