### PR TITLE
CUDA perf: cuBLASLt transpose-B view for M=1 GEMMs

### DIFF
--- a/PR_NOTES_CUDA_WSL2.md
+++ b/PR_NOTES_CUDA_WSL2.md
@@ -15,6 +15,7 @@ The CUDA runtime uses the CUDA Driver API (`libcuda`) and embeds a CUBIN for cus
   - `cuInit`, primary context, non-blocking stream
   - cuBLAS + (optional) cuBLASLt for small `M=1` GEMMs
   - Optional cuBLASLt autotune for `M=1` decoder GEMMs (enabled by `VOX_CUDA_FAST=1`; disable with `VOX_DISABLE_CUBLASLT_AUTOTUNE=1`)
+  - Optional cuBLASLt transpose-B view for `M=1` decoder GEMMs (enabled by `VOX_CUDA_FAST=1`; disable with `VOX_DISABLE_CUBLASLT_TRANSPOSE_B=1`)
 - Custom CUDA kernels:
   - Built via `nvcc -cubin` and embedded as a C header (no PTX JIT at runtime).
   - Implements RMSNorm, RoPE, BF16/FP16 casts, SwiGLU/GELU, downsample concat, argmax, etc.

--- a/README.md
+++ b/README.md
@@ -411,6 +411,7 @@ VOX_CUDA_FAST=1 ./voxtral -d voxtral-model -i samples/test_speech.wav
 Notes:
 - `VOX_CUDA_FAST=1` enables a fused top1-only logits path by default when alternatives are disabled (`--alt` not used). Disable it with `VOX_DISABLE_CUDA_LOGITS_FUSED=1` if you want to benchmark the baseline logits+argmax path.
 - `VOX_CUDA_FAST=1` also enables cuBLASLt autotune for the `M=1` decoder GEMMs (best-effort). Disable it with `VOX_DISABLE_CUBLASLT_AUTOTUNE=1`.
+- `VOX_CUDA_FAST=1` also enables a cuBLASLt “transpose-B view” for `M=1` decoder GEMMs (best-effort). Disable it with `VOX_DISABLE_CUBLASLT_TRANSPOSE_B=1` (or force it with `VOX_CUDA_CUBLASLT_TRANSPOSE_B=0/1`).
 
 To run the extra CUDA benchmark variants (graphs/v3/merged/etc):
 


### PR DESCRIPTION
This adds an optional cuBLASLt layout variant for the repeated decoder `M=1` BF16 GEMMs.

### What
- New “transpose-B view” path: weights are stored on device as row-major `N x K` BF16, but we describe `B` to cuBLASLt as **column-major `K x N`** (a zero-copy transposed view) and use `transb = N`.
- Default ON under `VOX_CUDA_FAST=1`.

Env knobs:
- Disable: `VOX_DISABLE_CUBLASLT_TRANSPOSE_B=1`
- Force: `VOX_CUDA_CUBLASLT_TRANSPOSE_B=0/1`

### Why
This can improve cuBLASLt algo selection / memory access patterns for these `M=1` GEMMs without duplicating weights in VRAM.

### Bench (RTX 3080 Ti 12GB, WSL2, CUDA 13.1)
`VOX_PRINT_TIMINGS=1` transcribe timing excludes model load.

`/tmp/vox_iad.wav` (180.021s), `VOX_CUDA_FAST=1`:
- transpose-B ON (default): wall 33.642s => 5.35xRT; decoder 13.1 ms/step
- transpose-B OFF (`VOX_DISABLE_CUBLASLT_TRANSPOSE_B=1`): wall 33.908s => 5.31xRT; decoder 13.2 ms/step

Delta: about -0.8% wall, -0.8% ms/step.

Fixes #15
