### PR TITLE
cuda: decoder attention v5 skips inactive chunks

### DIFF
--- a/PR_NOTES_CUDA_WSL2.md
+++ b/PR_NOTES_CUDA_WSL2.md
@@ -147,6 +147,25 @@ On `samples/antirez_speaking_italian_short.ogg` (converted to WAV; 60s), v3 is a
 
 When CUDA Graphs are enabled, v3 is auto-selected for the graph capture path if available (unless disabled via `VOX_DISABLE_CUDA_ATTN_V3=1`).
 
+### Attention v5 (opt-in)
+
+Enable with:
+
+```bash
+VOX_CUDA_ATTN_V5=1
+```
+
+Notes:
+- v5 is currently implemented for FP16 KV cache only (`VOX_CUDA_KV_FP16=1`, which is the default).
+- v5 keeps the same kernel grid shape as v4 (graph-capture safe), but reduces wasted work for shorter sequences by:
+  - skipping inactive chunks in the partial kernel (no zero-filling)
+  - iterating only the active chunks in the reduce kernel (instead of all `VOX_DEC_WINDOW`-derived chunks)
+
+On `/tmp/vox_iad.wav` (~180s WAV) with `VOX_CUDA_FAST=1`:
+
+- Baseline (v4): `Wall transcribe 33470 ms`, decoder `13.1 ms/step`
+- With v5: `Wall transcribe 33037 ms`, decoder `12.9 ms/step`
+
 ### Merged Decoder Projections (opt-in)
 
 Enable with:

--- a/README.md
+++ b/README.md
@@ -410,6 +410,8 @@ VOX_CUDA_FAST=1 ./voxtral -d voxtral-model -i samples/test_speech.wav
 
 Notes:
 - `VOX_CUDA_FAST=1` enables a fused top1-only logits path by default when alternatives are disabled (`--alt` not used). Disable it with `VOX_DISABLE_CUDA_LOGITS_FUSED=1` if you want to benchmark the baseline logits+argmax path.
+- `VOX_CUDA_FAST=1` also enables the chunked attention v4 path by default (fused KV append into the v3 partial kernel, best-effort). Disable it with `VOX_DISABLE_CUDA_ATTN_V4=1`.
+- `VOX_CUDA_ATTN_V5=1` enables an experimental decoder attention variant that skips inactive chunks (best-effort; default off until validated broadly).
 - `VOX_CUDA_FAST=1` also enables cuBLASLt autotune for the `M=1` decoder GEMMs (best-effort). Disable it with `VOX_DISABLE_CUBLASLT_AUTOTUNE=1`.
 - `VOX_CUDA_FAST=1` also enables a cuBLASLt “transpose-B view” for `M=1` decoder GEMMs (best-effort). Disable it with `VOX_DISABLE_CUBLASLT_TRANSPOSE_B=1` (or force it with `VOX_CUDA_CUBLASLT_TRANSPOSE_B=0/1`).
 

--- a/scripts/benchmark_backends.sh
+++ b/scripts/benchmark_backends.sh
@@ -107,6 +107,7 @@ if [[ "${VOX_BENCH_CUDA_OPTS:-0}" == "1" ]]; then
   run_case cuda "cuda+graphs" VOX_CUDA_GRAPHS=1
   run_case cuda "cuda+attn_v3" VOX_CUDA_ATTN_V3=1
   run_case cuda "cuda+graphs+attn_v3" VOX_CUDA_GRAPHS=1 VOX_CUDA_ATTN_V3=1
+  run_case cuda "cuda+fast+attn_v5" VOX_CUDA_FAST=1 VOX_CUDA_ATTN_V5=1
   run_case cuda "cuda+merged_weights" VOX_CUDA_MERGE_WEIGHTS=1
   run_case cuda "cuda+graphs+merged_weights" VOX_CUDA_GRAPHS=1 VOX_CUDA_MERGE_WEIGHTS=1
   run_case cuda "cuda+graphs+merged_weights+rope_dev" VOX_CUDA_GRAPHS=1 VOX_CUDA_MERGE_WEIGHTS=1 VOX_CUDA_ROPE_DEV=1

--- a/voxtral_cuda_kernels.cu
+++ b/voxtral_cuda_kernels.cu
@@ -1486,6 +1486,442 @@ extern "C" __global__ void vox_attn_q4_kv8_fp16_dyn_v4_partial(float *out_part, 
     ((float4 *)(out_part + base_vec))[lane] = make_float4(out0, out1, out2, out3);
 }
 
+/* v5 decoder attention: reduce wasted work for short sequences.
+ *
+ * Motivation: v3/v4 are captured with a fixed `n_chunks` derived from VOX_DEC_WINDOW.
+ * For typical transcription runs, total_seq may be far smaller than VOX_DEC_WINDOW,
+ * meaning many chunk blocks are empty. v3/v4 write zero partials for these empty
+ * chunks, and the reduce kernel still reads/iterates them.
+ *
+ * v5 keeps the same grid shape and memory layout, but:
+ * - partial: returns immediately for empty chunks (no global stores)
+ * - reduce: loops only over active chunks (derived from total_seq/pos)
+ *
+ * This is opt-in via VOX_CUDA_ATTN_V5=1. */
+
+extern "C" __global__ void vox_attn_q4_kv8_fp16_v5_partial(float *out_part,        /* [32*n_chunks*128] */
+                                                          float *max_part,        /* [32*n_chunks] */
+                                                          float *sum_part,        /* [32*n_chunks] */
+                                                          const float *q,         /* [32*128] */
+                                                          __half *k_cache,        /* [max_seq*8*128] */
+                                                          __half *v_cache,        /* [max_seq*8*128] */
+                                                          const float *k_in,      /* [8*128] */
+                                                          const float *v_in,      /* [8*128] */
+                                                          int total_seq,
+                                                          int window_size,
+                                                          float scale,
+                                                          int n_chunks) {
+    int kv_h = (int)blockIdx.x;  /* 0..7 */
+    int chunk = (int)blockIdx.y; /* 0..n_chunks-1 */
+    int tid = (int)threadIdx.x;  /* 0..127 */
+    int warp = tid >> 5;         /* 0..3 */
+    int lane = tid & 31;         /* 0..31 */
+    if (kv_h >= 8 || warp >= 4) return;
+
+    int h = kv_h * 4 + warp; /* query head 0..31 */
+
+    int end = total_seq;
+    int pos = end - 1;
+    if (pos < 0) pos = 0;
+
+    int start = 0;
+    if (window_size > 0) {
+        int s = end - window_size;
+        if (s > 0) start = s;
+    }
+    if (start < 0) start = 0;
+    if (end < start) end = start;
+
+    int chunk_start = start + chunk * VOX_ATTN_V3_CHUNK;
+    int chunk_end = chunk_start + VOX_ATTN_V3_CHUNK;
+    if (chunk_start > end) chunk_start = end;
+    if (chunk_end > end) chunk_end = end;
+
+    if (chunk_start >= chunk_end) {
+        /* Empty chunk: do not touch out_part/max_part/sum_part. v5 reduce
+         * ignores inactive chunks. */
+        return;
+    }
+
+    int base_max = h * n_chunks + chunk;
+    size_t base_vec = ((size_t)base_max) * (size_t)128;
+
+    const float4 qv = ((const float4 *)(q + h * 128))[lane];
+
+    float max_score = -1.0e30f;
+    float sum_exp = 0.0f;
+    float out0 = 0.0f, out1 = 0.0f, out2 = 0.0f, out3 = 0.0f;
+
+    const __half2 *k2 = (const __half2 *)k_cache;
+    const __half2 *v2 = (const __half2 *)v_cache;
+    __half2 *k2w = (__half2 *)k_cache;
+    __half2 *v2w = (__half2 *)v_cache;
+    size_t row_stride = (size_t)(8 * 128) / 2;
+    size_t head_off = (size_t)kv_h * (size_t)128 / 2;
+
+    __shared__ __half2 shK[VOX_ATTN_V3_TILE][64];
+    __shared__ __half2 shV[VOX_ATTN_V3_TILE][64];
+
+    int off2 = lane * 2;
+
+    for (int j0 = chunk_start; j0 < chunk_end; j0 += VOX_ATTN_V3_TILE) {
+#pragma unroll
+        for (int t = 0; t < VOX_ATTN_V3_TILE; t++) {
+            int j = j0 + t;
+            if (j >= chunk_end) continue;
+
+            if (j == pos) {
+                /* Fuse: load current-token K/V from inputs, and write to cache. */
+                if (tid < 64) {
+                    int i = tid * 2;
+                    float f0 = k_in[kv_h * 128 + i + 0];
+                    float f1 = k_in[kv_h * 128 + i + 1];
+                    __half2 hv = __floats2half2_rn(f0, f1);
+                    shK[t][tid] = hv;
+                    k2w[(size_t)pos * row_stride + head_off + (size_t)tid] = hv;
+                } else {
+                    int tv = tid - 64;
+                    int i = tv * 2;
+                    float f0 = v_in[kv_h * 128 + i + 0];
+                    float f1 = v_in[kv_h * 128 + i + 1];
+                    __half2 hv = __floats2half2_rn(f0, f1);
+                    shV[t][tv] = hv;
+                    v2w[(size_t)pos * row_stride + head_off + (size_t)tv] = hv;
+                }
+            } else {
+                const __half2 *k_row = k2 + (size_t)j * row_stride + head_off;
+                const __half2 *v_row = v2 + (size_t)j * row_stride + head_off;
+                if (tid < 64) {
+                    shK[t][tid] = k_row[tid];
+                } else {
+                    shV[t][tid - 64] = v_row[tid - 64];
+                }
+            }
+        }
+        __syncthreads();
+
+#pragma unroll
+        for (int t = 0; t < VOX_ATTN_V3_TILE; t++) {
+            int j = j0 + t;
+            if (j >= chunk_end) break;
+
+            float2 k01 = __half22float2(shK[t][off2 + 0]);
+            float2 k23 = __half22float2(shK[t][off2 + 1]);
+            float partial = qv.x * k01.x + qv.y * k01.y + qv.z * k23.x + qv.w * k23.y;
+            float sum = warp_reduce_sum(partial);
+            sum = __shfl_sync(0xffffffff, sum, 0);
+            float score = sum * scale;
+
+            float w = 0.0f;
+            float corr = 1.0f;
+            int new_max = 0;
+            if (lane == 0) {
+                if (score > max_score) {
+                    corr = __expf(max_score - score);
+                    sum_exp = sum_exp * corr + 1.0f;
+                    max_score = score;
+                    w = 1.0f;
+                    new_max = 1;
+                } else {
+                    w = __expf(score - max_score);
+                    sum_exp += w;
+                    corr = 1.0f;
+                    new_max = 0;
+                }
+            }
+            w = __shfl_sync(0xffffffff, w, 0);
+            corr = __shfl_sync(0xffffffff, corr, 0);
+            new_max = __shfl_sync(0xffffffff, new_max, 0);
+
+            float2 v01 = __half22float2(shV[t][off2 + 0]);
+            float2 v23 = __half22float2(shV[t][off2 + 1]);
+            if (new_max) {
+                out0 = out0 * corr + v01.x;
+                out1 = out1 * corr + v01.y;
+                out2 = out2 * corr + v23.x;
+                out3 = out3 * corr + v23.y;
+            } else {
+                out0 += w * v01.x;
+                out1 += w * v01.y;
+                out2 += w * v23.x;
+                out3 += w * v23.y;
+            }
+        }
+        __syncthreads();
+    }
+
+    if (lane == 0) {
+        max_part[base_max] = max_score;
+        sum_part[base_max] = sum_exp;
+    }
+    ((float4 *)(out_part + base_vec))[lane] = make_float4(out0, out1, out2, out3);
+}
+
+extern "C" __global__ void vox_attn_q4_kv8_fp16_dyn_v5_partial(float *out_part,        /* [32*n_chunks*128] */
+                                                              float *max_part,        /* [32*n_chunks] */
+                                                              float *sum_part,        /* [32*n_chunks] */
+                                                              const float *q,         /* [32*128] */
+                                                              __half *k_cache,        /* [max_seq*8*128] */
+                                                              __half *v_cache,        /* [max_seq*8*128] */
+                                                              const float *k_in,      /* [8*128] */
+                                                              const float *v_in,      /* [8*128] */
+                                                              const int *p_pos,
+                                                              int window_size,
+                                                              float scale,
+                                                              int n_chunks) {
+    int kv_h = (int)blockIdx.x;
+    int chunk = (int)blockIdx.y;
+    int tid = (int)threadIdx.x;
+    int warp = tid >> 5;
+    int lane = tid & 31;
+    if (kv_h >= 8 || warp >= 4) return;
+
+    int h = kv_h * 4 + warp;
+
+    int pos = 0;
+    if (lane == 0) pos = *p_pos;
+    pos = __shfl_sync(0xffffffff, pos, 0);
+    int end = pos + 1;
+
+    int start = 0;
+    if (window_size > 0) {
+        int s = end - window_size;
+        if (s > 0) start = s;
+    }
+    if (start < 0) start = 0;
+    if (end < start) end = start;
+
+    int chunk_start = start + chunk * VOX_ATTN_V3_CHUNK;
+    int chunk_end = chunk_start + VOX_ATTN_V3_CHUNK;
+    if (chunk_start > end) chunk_start = end;
+    if (chunk_end > end) chunk_end = end;
+
+    if (chunk_start >= chunk_end) {
+        return;
+    }
+
+    int base_max = h * n_chunks + chunk;
+    size_t base_vec = ((size_t)base_max) * (size_t)128;
+
+    const float4 qv = ((const float4 *)(q + h * 128))[lane];
+
+    float max_score = -1.0e30f;
+    float sum_exp = 0.0f;
+    float out0 = 0.0f, out1 = 0.0f, out2 = 0.0f, out3 = 0.0f;
+
+    const __half2 *k2 = (const __half2 *)k_cache;
+    const __half2 *v2 = (const __half2 *)v_cache;
+    __half2 *k2w = (__half2 *)k_cache;
+    __half2 *v2w = (__half2 *)v_cache;
+    size_t row_stride = (size_t)(8 * 128) / 2;
+    size_t head_off = (size_t)kv_h * (size_t)128 / 2;
+
+    __shared__ __half2 shK[VOX_ATTN_V3_TILE][64];
+    __shared__ __half2 shV[VOX_ATTN_V3_TILE][64];
+
+    int off2 = lane * 2;
+
+    for (int j0 = chunk_start; j0 < chunk_end; j0 += VOX_ATTN_V3_TILE) {
+#pragma unroll
+        for (int t = 0; t < VOX_ATTN_V3_TILE; t++) {
+            int j = j0 + t;
+            if (j >= chunk_end) continue;
+
+            if (j == pos) {
+                if (tid < 64) {
+                    int i = tid * 2;
+                    float f0 = k_in[kv_h * 128 + i + 0];
+                    float f1 = k_in[kv_h * 128 + i + 1];
+                    __half2 hv = __floats2half2_rn(f0, f1);
+                    shK[t][tid] = hv;
+                    k2w[(size_t)pos * row_stride + head_off + (size_t)tid] = hv;
+                } else {
+                    int tv = tid - 64;
+                    int i = tv * 2;
+                    float f0 = v_in[kv_h * 128 + i + 0];
+                    float f1 = v_in[kv_h * 128 + i + 1];
+                    __half2 hv = __floats2half2_rn(f0, f1);
+                    shV[t][tv] = hv;
+                    v2w[(size_t)pos * row_stride + head_off + (size_t)tv] = hv;
+                }
+            } else {
+                const __half2 *k_row = k2 + (size_t)j * row_stride + head_off;
+                const __half2 *v_row = v2 + (size_t)j * row_stride + head_off;
+                if (tid < 64) {
+                    shK[t][tid] = k_row[tid];
+                } else {
+                    shV[t][tid - 64] = v_row[tid - 64];
+                }
+            }
+        }
+        __syncthreads();
+
+#pragma unroll
+        for (int t = 0; t < VOX_ATTN_V3_TILE; t++) {
+            int j = j0 + t;
+            if (j >= chunk_end) break;
+
+            float2 k01 = __half22float2(shK[t][off2 + 0]);
+            float2 k23 = __half22float2(shK[t][off2 + 1]);
+            float partial = qv.x * k01.x + qv.y * k01.y + qv.z * k23.x + qv.w * k23.y;
+            float sum = warp_reduce_sum(partial);
+            sum = __shfl_sync(0xffffffff, sum, 0);
+            float score = sum * scale;
+
+            float w = 0.0f;
+            float corr = 1.0f;
+            int new_max = 0;
+            if (lane == 0) {
+                if (score > max_score) {
+                    corr = __expf(max_score - score);
+                    sum_exp = sum_exp * corr + 1.0f;
+                    max_score = score;
+                    w = 1.0f;
+                    new_max = 1;
+                } else {
+                    w = __expf(score - max_score);
+                    sum_exp += w;
+                    corr = 1.0f;
+                    new_max = 0;
+                }
+            }
+            w = __shfl_sync(0xffffffff, w, 0);
+            corr = __shfl_sync(0xffffffff, corr, 0);
+            new_max = __shfl_sync(0xffffffff, new_max, 0);
+
+            float2 v01 = __half22float2(shV[t][off2 + 0]);
+            float2 v23 = __half22float2(shV[t][off2 + 1]);
+            if (new_max) {
+                out0 = out0 * corr + v01.x;
+                out1 = out1 * corr + v01.y;
+                out2 = out2 * corr + v23.x;
+                out3 = out3 * corr + v23.y;
+            } else {
+                out0 += w * v01.x;
+                out1 += w * v01.y;
+                out2 += w * v23.x;
+                out3 += w * v23.y;
+            }
+        }
+        __syncthreads();
+    }
+
+    if (lane == 0) {
+        max_part[base_max] = max_score;
+        sum_part[base_max] = sum_exp;
+    }
+    ((float4 *)(out_part + base_vec))[lane] = make_float4(out0, out1, out2, out3);
+}
+
+extern "C" __global__ void vox_attn_q4_kv8_fp16_v5_reduce(float *out_q,           /* [32*128] */
+                                                         const float *out_part, /* [32*n_chunks*128] */
+                                                         const float *max_part, /* [32*n_chunks] */
+                                                         const float *sum_part, /* [32*n_chunks] */
+                                                         int n_chunks,
+                                                         int active_chunks) {
+    int h = (int)blockIdx.x;
+    int lane = (int)threadIdx.x;
+    if (h >= 32 || lane >= 32) return;
+
+    if (active_chunks < 1) active_chunks = 1;
+    if (active_chunks > n_chunks) active_chunks = n_chunks;
+
+    float m = -1.0e30f;
+    if (lane == 0) {
+        for (int c = 0; c < active_chunks; c++) {
+            float mc = max_part[h * n_chunks + c];
+            if (mc > m) m = mc;
+        }
+    }
+    m = __shfl_sync(0xffffffff, m, 0);
+
+    float4 acc4 = make_float4(0.f, 0.f, 0.f, 0.f);
+    float sum = 0.0f;
+    for (int c = 0; c < active_chunks; c++) {
+        int idx = h * n_chunks + c;
+        float mc = max_part[idx];
+        float sc = sum_part[idx];
+        float scale = __expf(mc - m);
+
+        if (lane == 0) sum += sc * scale;
+
+        size_t base_vec = ((size_t)idx) * (size_t)128;
+        float4 v4 = ((const float4 *)(out_part + base_vec))[lane];
+        acc4.x += v4.x * scale;
+        acc4.y += v4.y * scale;
+        acc4.z += v4.z * scale;
+        acc4.w += v4.w * scale;
+    }
+
+    float inv_sum = 0.0f;
+    if (lane == 0) inv_sum = (sum > 0.0f) ? (1.0f / sum) : 0.0f;
+    inv_sum = __shfl_sync(0xffffffff, inv_sum, 0);
+
+    ((float4 *)(out_q + h * 128))[lane] = make_float4(acc4.x * inv_sum,
+                                                      acc4.y * inv_sum,
+                                                      acc4.z * inv_sum,
+                                                      acc4.w * inv_sum);
+}
+
+extern "C" __global__ void vox_attn_q4_kv8_fp16_dyn_v5_reduce(float *out_q,           /* [32*128] */
+                                                             const float *out_part, /* [32*n_chunks*128] */
+                                                             const float *max_part, /* [32*n_chunks] */
+                                                             const float *sum_part, /* [32*n_chunks] */
+                                                             int n_chunks,
+                                                             const int *p_pos,
+                                                             int window_size) {
+    int h = (int)blockIdx.x;
+    int lane = (int)threadIdx.x;
+    if (h >= 32 || lane >= 32) return;
+
+    int pos = 0;
+    if (lane == 0) pos = *p_pos;
+    pos = __shfl_sync(0xffffffff, pos, 0);
+    int end = pos + 1;
+
+    int active_len = end;
+    if (window_size > 0 && active_len > window_size) active_len = window_size;
+    int active_chunks = (active_len + VOX_ATTN_V3_CHUNK - 1) / VOX_ATTN_V3_CHUNK;
+    if (active_chunks < 1) active_chunks = 1;
+    if (active_chunks > n_chunks) active_chunks = n_chunks;
+
+    float m = -1.0e30f;
+    if (lane == 0) {
+        for (int c = 0; c < active_chunks; c++) {
+            float mc = max_part[h * n_chunks + c];
+            if (mc > m) m = mc;
+        }
+    }
+    m = __shfl_sync(0xffffffff, m, 0);
+
+    float4 acc4 = make_float4(0.f, 0.f, 0.f, 0.f);
+    float sum = 0.0f;
+    for (int c = 0; c < active_chunks; c++) {
+        int idx = h * n_chunks + c;
+        float mc = max_part[idx];
+        float sc = sum_part[idx];
+        float scale = __expf(mc - m);
+
+        if (lane == 0) sum += sc * scale;
+
+        size_t base_vec = ((size_t)idx) * (size_t)128;
+        float4 v4 = ((const float4 *)(out_part + base_vec))[lane];
+        acc4.x += v4.x * scale;
+        acc4.y += v4.y * scale;
+        acc4.z += v4.z * scale;
+        acc4.w += v4.w * scale;
+    }
+
+    float inv_sum = 0.0f;
+    if (lane == 0) inv_sum = (sum > 0.0f) ? (1.0f / sum) : 0.0f;
+    inv_sum = __shfl_sync(0xffffffff, inv_sum, 0);
+
+    ((float4 *)(out_q + h * 128))[lane] = make_float4(acc4.x * inv_sum,
+                                                      acc4.y * inv_sum,
+                                                      acc4.z * inv_sum,
+                                                      acc4.w * inv_sum);
+}
+
 extern "C" __global__ void vox_attn_q4_kv8_fp16_v3_reduce(float *out_q,           /* [32*128] */
                                                           const float *out_part, /* [32*n_chunks*128] */
                                                           const float *max_part, /* [32*n_chunks] */


### PR DESCRIPTION
Fixes #17.

Changes:
- Add opt-in decoder attention v5 kernels (partial+reduce):
  - partial skips inactive chunks (no zero-filling)
  - reduce iterates only active chunks (derived from total_seq/pos)
- Wire v5 into both non-graph and CUDA-graph decoder paths (FP16 KV only).
- Add `VOX_CUDA_ATTN_V5=1` knob + docs + benchmark helper variant.

Bench (RTX 3080 Ti, WSL2, CUDA 13.1, `/tmp/vox_iad.wav` ~180s WAV, `VOX_CUDA_FAST=1`):
- Baseline (v4 default): `Wall transcribe 33470 ms`, decoder `13.1 ms/step`
- With v5: `Wall transcribe 33037 ms`, decoder `12.9 ms/step`

Validation:
- `make cuda`
- `./scripts/validate_cuda.sh`
- `./scripts/accuracy_regression.sh voxtral-model samples/test_speech.wav 0.005`
- `./runtest.sh`
