### PR TITLE
cuda: opt-in cuBLASLt computeType override for BF16 GEMMs

### DIFF
--- a/PR_NOTES_CUDA_WSL2.md
+++ b/PR_NOTES_CUDA_WSL2.md
@@ -16,6 +16,7 @@ The CUDA runtime uses the CUDA Driver API (`libcuda`) and embeds a CUBIN for cus
   - cuBLAS + (optional) cuBLASLt for small `M=1` GEMMs
   - Optional cuBLASLt autotune for `M=1` decoder GEMMs (enabled by `VOX_CUDA_FAST=1`; disable with `VOX_DISABLE_CUBLASLT_AUTOTUNE=1`)
   - Optional cuBLASLt transpose-B view for `M=1` decoder GEMMs (enabled by `VOX_CUDA_FAST=1`; disable with `VOX_DISABLE_CUBLASLT_TRANSPOSE_B=1`)
+  - Optional cuBLASLt computeType override for BF16 GEMMs: `VOX_CUDA_LT_COMPUTE=32F_FAST_16BF|32F_FAST_TF32|32F_FAST_16F` (default: `32F`)
 - Custom CUDA kernels:
   - Built via `nvcc -cubin` and embedded as a C header (no PTX JIT at runtime).
   - Implements RMSNorm, RoPE, BF16/FP16 casts, SwiGLU/GELU, downsample concat, argmax, etc.

--- a/README.md
+++ b/README.md
@@ -414,6 +414,7 @@ Notes:
 - `VOX_CUDA_ATTN_V5=1` enables an experimental decoder attention variant that skips inactive chunks (best-effort; default off until validated broadly).
 - `VOX_CUDA_FAST=1` also enables cuBLASLt autotune for the `M=1` decoder GEMMs (best-effort). Disable it with `VOX_DISABLE_CUBLASLT_AUTOTUNE=1`.
 - `VOX_CUDA_FAST=1` also enables a cuBLASLt “transpose-B view” for `M=1` decoder GEMMs (best-effort). Disable it with `VOX_DISABLE_CUBLASLT_TRANSPOSE_B=1` (or force it with `VOX_CUDA_CUBLASLT_TRANSPOSE_B=0/1`).
+- `VOX_CUDA_LT_COMPUTE=32F_FAST_16BF` (or similar) opts into alternate cuBLASLt compute modes for BF16 GEMMs (default: `32F`). This may change outputs slightly; use `./scripts/accuracy_regression.sh` to validate.
 
 To run the extra CUDA benchmark variants (graphs/v3/merged/etc):
 

--- a/scripts/benchmark_backends.sh
+++ b/scripts/benchmark_backends.sh
@@ -104,6 +104,7 @@ run_case cuda cuda
 if [[ "${VOX_BENCH_CUDA_OPTS:-0}" == "1" ]]; then
   echo "== extra CUDA variants (VOX_BENCH_CUDA_OPTS=1) =="
   run_case cuda "cuda+fast" VOX_CUDA_FAST=1
+  run_case cuda "cuda+fast+lt_fast_16bf" VOX_CUDA_FAST=1 VOX_CUDA_LT_COMPUTE=32F_FAST_16BF
   run_case cuda "cuda+graphs" VOX_CUDA_GRAPHS=1
   run_case cuda "cuda+attn_v3" VOX_CUDA_ATTN_V3=1
   run_case cuda "cuda+graphs+attn_v3" VOX_CUDA_GRAPHS=1 VOX_CUDA_ATTN_V3=1


### PR DESCRIPTION
Closes #16.

## What
Adds an opt-in env knob to select the cuBLASLt `computeType` used for BF16 `M=1` matmuls (decoder GEMMs):

- `VOX_CUDA_LT_COMPUTE=32F` (default)
- `VOX_CUDA_LT_COMPUTE=32F_FAST_16BF`
- `VOX_CUDA_LT_COMPUTE=32F_FAST_TF32`
- `VOX_CUDA_LT_COMPUTE=32F_FAST_16F`

This is strictly opt-in; default behavior remains FP32 accumulation.

Also updates the Lt algo cache key to include `computeType`, and adds a benchmark variant (`cuda+fast+lt_fast_16bf`) under `VOX_BENCH_CUDA_OPTS=1`.

## Bench (WSL2 RTX 3080 Ti, `/tmp/vox_iad.wav` ~180s)
`VOX_PRINT_TIMINGS=1 VOX_CUDA_FAST=1`

- `VOX_CUDA_LT_COMPUTE=32F` (default)
  - Wall transcribe: `32999 ms` (decoder `12.3 ms/step`)
  - Wall transcribe: `33229 ms` (decoder `13.0 ms/step`)
- `VOX_CUDA_LT_COMPUTE=32F_FAST_16BF`
  - Wall transcribe: `32981 ms` (decoder `12.9 ms/step`)
- `VOX_CUDA_LT_COMPUTE=32F_FAST_TF32`
  - Wall transcribe: `32956 ms` (decoder `12.9 ms/step`)

On this box the “fast” computeTypes did not produce a consistent win (within noise; sometimes slightly worse). The knob is still useful for experimentation across GPUs.

## Validation
- `./scripts/validate_cuda.sh voxtral-model samples/test_speech.wav`
- `./scripts/accuracy_regression.sh voxtral-model samples/test_speech.wav 0.005`
- `VOX_CUDA_LT_COMPUTE=32F_FAST_16BF ./scripts/accuracy_regression.sh voxtral-model samples/test_speech.wav 0.005`
- `./runtest.sh`