### PR TITLE
cuda: make pipeline full per-context + thread-safe (Issue #19)

### DIFF
--- a/PR_NOTES_CUDA_WSL2.md
+++ b/PR_NOTES_CUDA_WSL2.md
@@ -223,10 +223,11 @@ This keeps streaming adapter embeddings on-device and lets CUDA build the per-st
 - Avoids uploading a new step embedding (`HtoD`) every generated token.
 
 Notes:
-- Experimental and currently **not thread-safe** (uses a global device-side adapter buffer).
+- Experimental. Thread-safe across multiple `vox_ctx_t` instances (CUDA backend serializes calls via a global lock).
 - If it fails mid-run, we currently fail-fast rather than attempting a CPU fallback.
 - Prompt prefill still copies only the first prompt window from device to host to reuse the existing prefill path.
 - In pipeline mode, GPU conv stem is attempted by default unless disabled (`VOX_DISABLE_CUDA_CONV_STEM=1`).
+- Concurrency smoke test: `./scripts/stress_cuda_two_streams.sh voxtral-model samples/test_speech.wav`
 
 Related env vars:
 - `VOX_DISABLE_CUDA_PIPELINE_FULL=1` disables the pipeline.

--- a/scripts/stress_cuda_two_streams.sh
+++ b/scripts/stress_cuda_two_streams.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MODEL_DIR="${1:-voxtral-model}"
+SAMPLE_FILE="${2:-samples/test_speech.wav}"
+
+make cuda
+
+SAMPLE_WAV="$SAMPLE_FILE"
+tmp_wav=""
+lower="${SAMPLE_FILE,,}"
+if [[ "$lower" != *.wav ]]; then
+  if ! command -v ffmpeg >/dev/null 2>&1; then
+    echo "[err] input is not .wav and ffmpeg is not installed: '$SAMPLE_FILE'"
+    exit 1
+  fi
+  tmp_wav="/tmp/voxtral_stress_two_streams_${$}.wav"
+  ffmpeg -y -hide_banner -loglevel error -i "$SAMPLE_FILE" -ac 1 -ar 16000 "$tmp_wav"
+  SAMPLE_WAV="$tmp_wav"
+  trap 'rm -f "$tmp_wav"' EXIT
+fi
+
+BIN="/tmp/voxtral_stress_two_streams"
+OBJ="/tmp/voxtral_stress_two_streams.o"
+
+gcc -O2 -Wall -Wextra -pthread -I. -c -o "$OBJ" scripts/stress_two_streams.c
+gcc -o "$BIN" \
+  "$OBJ" \
+  voxtral.o voxtral_kernels.o voxtral_audio.o voxtral_encoder.o voxtral_decoder.o voxtral_tokenizer.o \
+  voxtral_safetensors.o voxtral_mic_macos.o voxtral_cuda_stub.o voxtral_cuda.o \
+  -lm -fopenmp -L/usr/local/cuda/lib64 -L/usr/local/cuda/lib64/stubs -lcublasLt -lcublas -lcuda
+
+echo "[info] two-stream stress: VOX_CUDA_PIPELINE_FULL=1 VOX_CUDA_FAST=1"
+VOX_CUDA_PIPELINE_FULL=1 VOX_CUDA_FAST=1 "$BIN" "$MODEL_DIR" "$SAMPLE_WAV"
+echo "[ok] two-stream stress passed"
+

--- a/scripts/stress_two_streams.c
+++ b/scripts/stress_two_streams.c
@@ -1,0 +1,85 @@
+#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "voxtral.h"
+
+extern int vox_verbose;
+
+typedef struct {
+    int tid;
+    vox_ctx_t *ctx;
+    const char *wav_path;
+    char *out;
+    int ok;
+} task_t;
+
+static void *run_transcribe(void *arg) {
+    task_t *t = (task_t *)arg;
+    t->out = vox_transcribe(t->ctx, t->wav_path);
+    if (!t->out) {
+        fprintf(stderr, "[t%d] vox_transcribe failed\n", t->tid);
+        t->ok = 0;
+        return NULL;
+    }
+    size_t n = strlen(t->out);
+    fprintf(stderr, "[t%d] transcript bytes=%zu\n", t->tid, n);
+    t->ok = (n > 0);
+    return NULL;
+}
+
+int main(int argc, char **argv) {
+    const char *model_dir = (argc > 1) ? argv[1] : "voxtral-model";
+    const char *wav_path = (argc > 2) ? argv[2] : "samples/test_speech.wav";
+
+    /* Keep noise low; this is meant as a concurrency smoke test. */
+    vox_verbose = 0;
+
+    vox_ctx_t *ctx1 = vox_load(model_dir);
+    if (!ctx1) {
+        fprintf(stderr, "[err] vox_load failed for ctx1 (model_dir=%s)\n", model_dir);
+        return 1;
+    }
+    vox_ctx_t *ctx2 = vox_load(model_dir);
+    if (!ctx2) {
+        fprintf(stderr, "[err] vox_load failed for ctx2 (model_dir=%s)\n", model_dir);
+        vox_free(ctx1);
+        return 1;
+    }
+
+    task_t t1 = { .tid = 1, .ctx = ctx1, .wav_path = wav_path, .out = NULL, .ok = 0 };
+    task_t t2 = { .tid = 2, .ctx = ctx2, .wav_path = wav_path, .out = NULL, .ok = 0 };
+
+    pthread_t th1, th2;
+    if (pthread_create(&th1, NULL, run_transcribe, &t1) != 0) {
+        fprintf(stderr, "[err] pthread_create(th1) failed\n");
+        vox_free(ctx1);
+        vox_free(ctx2);
+        return 1;
+    }
+    if (pthread_create(&th2, NULL, run_transcribe, &t2) != 0) {
+        fprintf(stderr, "[err] pthread_create(th2) failed\n");
+        pthread_join(th1, NULL);
+        free(t1.out);
+        vox_free(ctx1);
+        vox_free(ctx2);
+        return 1;
+    }
+
+    pthread_join(th1, NULL);
+    pthread_join(th2, NULL);
+
+    int ok = (t1.ok && t2.ok);
+    if (ok && t1.out && t2.out && strcmp(t1.out, t2.out) != 0) {
+        fprintf(stderr, "[warn] transcripts differ between threads\n");
+    }
+
+    free(t1.out);
+    free(t2.out);
+    vox_free(ctx1);
+    vox_free(ctx2);
+
+    return ok ? 0 : 1;
+}
+

--- a/voxtral_cuda_stub.c
+++ b/voxtral_cuda_stub.c
@@ -38,7 +38,8 @@ int vox_cuda_linear2_bf16(float *y0, float *y1,
     return 0;
 }
 
-int vox_cuda_attention_step(float *attn_out,
+int vox_cuda_attention_step(vox_ctx_t *ctx,
+                            float *attn_out,
                             const float *q,
                             const float *k,
                             const float *v,
@@ -46,20 +47,25 @@ int vox_cuda_attention_step(float *attn_out,
                             int pos,
                             int total_seq,
                             int window_size) {
-    (void)attn_out; (void)q; (void)k; (void)v; (void)layer; (void)pos; (void)total_seq; (void)window_size;
+    (void)ctx; (void)attn_out; (void)q; (void)k; (void)v; (void)layer; (void)pos; (void)total_seq; (void)window_size;
     return 0;
 }
 
-void vox_cuda_kv_cache_compact(int discard, int keep, int kv_dim, int max_seq) {
-    (void)discard; (void)keep; (void)kv_dim; (void)max_seq;
+void vox_cuda_kv_cache_compact(vox_ctx_t *ctx, int discard, int keep, int kv_dim, int max_seq) {
+    (void)ctx; (void)discard; (void)keep; (void)kv_dim; (void)max_seq;
 }
 
-void vox_cuda_kv_cache_reset(void) {}
+void vox_cuda_kv_cache_reset(vox_ctx_t *ctx) { (void)ctx; }
 
-void vox_cuda_kv_cache_append_block(int layer, int start_pos, int seq_len,
+void vox_cuda_kv_cache_append_block(vox_ctx_t *ctx, int layer, int start_pos, int seq_len,
                                     int kv_dim, int window_size,
                                     const float *k, const float *v) {
-    (void)layer; (void)start_pos; (void)seq_len; (void)kv_dim; (void)window_size; (void)k; (void)v;
+    (void)ctx; (void)layer; (void)start_pos; (void)seq_len; (void)kv_dim; (void)window_size; (void)k; (void)v;
+}
+
+int vox_cuda_kv_cache_download_host(vox_ctx_t *ctx, int start_pos, int n_pos) {
+    (void)ctx; (void)start_pos; (void)n_pos;
+    return 0;
 }
 
 int vox_cuda_causal_attention(float *out,
@@ -89,15 +95,15 @@ int vox_cuda_encode_adapter(float **out, int *out_tokens,
     return 0;
 }
 
-void vox_cuda_stream_adapter_reset(void) {}
+void vox_cuda_stream_adapter_reset(vox_ctx_t *ctx) { (void)ctx; }
 
-int vox_cuda_stream_adapter_copy_prompt(float *out_host, int n_tokens) {
-    (void)out_host; (void)n_tokens;
+int vox_cuda_stream_adapter_copy_prompt(vox_ctx_t *ctx, float *out_host, int n_tokens) {
+    (void)ctx; (void)out_host; (void)n_tokens;
     return 0;
 }
 
-void vox_cuda_stream_adapter_compact(int consumed_tokens) {
-    (void)consumed_tokens;
+void vox_cuda_stream_adapter_compact(vox_ctx_t *ctx, int consumed_tokens) {
+    (void)ctx; (void)consumed_tokens;
 }
 
 int vox_cuda_encode_adapter_stream_append(int *out_tokens,
@@ -139,5 +145,7 @@ int vox_cuda_prefetch_weights(vox_ctx_t *ctx) {
 }
 
 void vox_cuda_shutdown(void) {}
+
+void vox_cuda_ctx_free(vox_ctx_t *ctx) { (void)ctx; }
 
 #endif /* !USE_CUDA */

--- a/voxtral_decoder.c
+++ b/voxtral_decoder.c
@@ -240,7 +240,7 @@ static void kv_cache_compact(vox_ctx_t *ctx) {
     }
 
 #ifdef USE_CUDA
-    vox_cuda_kv_cache_compact(discard, keep, kv_dim, ctx->kv_cache_max);
+    vox_cuda_kv_cache_compact(ctx, discard, keep, kv_dim, ctx->kv_cache_max);
 #endif
 
     ctx->kv_cache_host_valid_len = new_valid;
@@ -361,7 +361,7 @@ void vox_decoder_prefill(vox_ctx_t *ctx, const float *input_embeds, int seq_len)
         }
 #ifdef USE_CUDA
         /* Keep device-side KV cache in sync for the upcoming single-token decode loop. */
-        vox_cuda_kv_cache_append_block(layer, start_pos, seq_len, kv_dim, VOX_DEC_WINDOW, k, v);
+        vox_cuda_kv_cache_append_block(ctx, layer, start_pos, seq_len, kv_dim, VOX_DEC_WINDOW, k, v);
 #endif
 
         /* Causal attention over full cached sequence */
@@ -560,7 +560,7 @@ int vox_decoder_forward(vox_ctx_t *ctx, const float *input_embeds, float *logits
         float *full_v = kv_cache_v_at(ctx, layer, 0);
 
 #ifdef USE_CUDA
-        if (!vox_cuda_attention_step(attn_out, q, k, v, layer, pos, total_seq, VOX_DEC_WINDOW))
+        if (!vox_cuda_attention_step(ctx, attn_out, q, k, v, layer, pos, total_seq, VOX_DEC_WINDOW))
 #endif
         {
             vox_causal_attention(attn_out, q, full_k, full_v,


### PR DESCRIPTION
Fixes #19.

## What changed
- VOX_CUDA_PIPELINE_FULL is now **per-vox_ctx_t** (device-side adapter buffer + decoder device KV cache are tracked per context).
- CUDA backend is now **thread-safe via serialization**: a global re-entrant lock guards all CUDA entrypoints so multiple streams/contexts can be used concurrently without corruption (work is still serialized on the GPU).
- Removed the old single-stream fail-fast lock in `voxtral.c`.
- Added per-context CUDA cleanup: `vox_cuda_ctx_free(ctx)` is called from `vox_free(ctx)`.
- Added a concurrency smoke test: `scripts/stress_cuda_two_streams.sh` (2 threads, 2 contexts, pipeline full).

## Notes
- CUDA graphs are automatically disabled when multiple contexts are active (graphs bake device pointers).

## Validation
- `make cuda`
- `./scripts/validate_cuda.sh voxtral-model samples/test_speech.wav`
- `./scripts/accuracy_regression.sh voxtral-model samples/test_speech.wav 0.005`
- `./runtest.sh`
- `./scripts/validate_cuda_pipeline_compact.sh voxtral-model samples/test_speech.wav`
- `./scripts/stress_cuda_two_streams.sh voxtral-model samples/test_speech.wav`