### PR TITLE
cuda: opt-in INT8 fused top1 logits (LM head)

### DIFF
--- a/scripts/benchmark_backends.sh
+++ b/scripts/benchmark_backends.sh
@@ -104,6 +104,7 @@ run_case cuda cuda
 if [[ "${VOX_BENCH_CUDA_OPTS:-0}" == "1" ]]; then
   echo "== extra CUDA variants (VOX_BENCH_CUDA_OPTS=1) =="
   run_case cuda "cuda+fast" VOX_CUDA_FAST=1
+  run_case cuda "cuda+fast+logits_int8" VOX_CUDA_FAST=1 VOX_CUDA_LOGITS_INT8=1
   run_case cuda "cuda+fast+lt_fast_16bf" VOX_CUDA_FAST=1 VOX_CUDA_LT_COMPUTE=32F_FAST_16BF
   run_case cuda "cuda+graphs" VOX_CUDA_GRAPHS=1
   run_case cuda "cuda+attn_v3" VOX_CUDA_ATTN_V3=1


### PR DESCRIPTION
Implements HorizonXP/voxtral.c#20.

### What changed
- Adds an **opt-in** INT8-quantized LM head (tok embeddings) for the common greedy/top1 path (when `logits==NULL`).
- New env knob: `VOX_CUDA_LOGITS_INT8=1` (default off; accuracy may change).
- Quantizes tok embeddings to INT8 (per-row scales) and runs a fused DP4A argmax kernel:
  - `vox_f32_vec_to_i8`
  - `vox_logits_best_i8_top1`
- Integrates with the decoder CUDA-graph capture path (logits mode becomes: matmul / bf16_fused / int8_fused).
- Updates `scripts/benchmark_backends.sh` to include `cuda+fast+logits_int8`.
- Updates `PR_NOTES_CUDA_WSL2.md` with benchmark numbers + docs.

### Bench (WSL2 RTX 3080 Ti, `samples/I_have_a_dream.ogg` = 180.021s)
- `VOX_CUDA_FAST=1`: Wall `35218 ms` (~5.11xRT), decoder `13.7 ms/step`
- `VOX_CUDA_FAST=1 VOX_CUDA_LOGITS_INT8=1`: Wall `32529 ms` (~5.53xRT), decoder `12.6 ms/step`
  - Also reduces BF16 cache pressure by avoiding uploading BF16 tok embeddings for logits (offline path).

### Accuracy
- Strictly opt-in (INT8 can change token choices).
- On `samples/test_speech.wav`, mismatch vs default CUDA was `0.0%` in a quick spot-check.

### Tests run
- `make cuda`
- `./runtest.sh`
- `./scripts/validate_cuda.sh voxtral-model samples/test_speech.wav`
- `./scripts/accuracy_regression.sh voxtral-model samples/test_speech.wav 0.005`
