### PR TITLE
cuda: 5090 build compatibility + default fast decoder mode (credit: @taf2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,21 +402,22 @@ If your RTX 3080 Ti is visible there, `make cuda` should work and Voxtral will o
 ./scripts/benchmark_backends.sh voxtral-model samples/test_speech.wav
 ```
 
-Fast CUDA config (best-effort, can be overridden by per-feature env vars):
+Fast CUDA config is enabled by default (best-effort, can be overridden by per-feature env vars):
 
 ```bash
-VOX_CUDA_FAST=1 ./voxtral -d voxtral-model -i samples/test_speech.wav
+./voxtral -d voxtral-model -i samples/test_speech.wav
 ```
 
 Notes:
-- `VOX_CUDA_FAST=1` enables a fused top1-only logits path by default when alternatives are disabled (`--alt` not used). Disable it with `VOX_DISABLE_CUDA_LOGITS_FUSED=1` if you want to benchmark the baseline logits+argmax path.
-- `VOX_CUDA_FAST=1` also enables the chunked attention v5 path by default (skips inactive chunks; best-effort). Disable it with `VOX_DISABLE_CUDA_ATTN_V5=1` (or force it with `VOX_CUDA_ATTN_V5=0/1`).
+- Default fast mode enables a fused top1-only logits path when alternatives are disabled (`--alt` not used). Disable it with `VOX_DISABLE_CUDA_LOGITS_FUSED=1` if you want to benchmark the baseline logits+argmax path.
+- Default fast mode also enables the chunked attention v5 path by default (skips inactive chunks; best-effort). Disable it with `VOX_DISABLE_CUDA_ATTN_V5=1` (or force it with `VOX_CUDA_ATTN_V5=0/1`).
 - `VOX_CUDA_ATTN_V6=1` enables an experimental v6 attention variant that stores chunk partials in FP16 to reduce global bandwidth. This may change outputs slightly; use `./scripts/accuracy_regression.sh` to validate.
-- `VOX_CUDA_FAST=1` also enables the chunked attention v4 path by default as a fallback when v5 is unavailable/disabled (fused KV append into the v3 partial kernel, best-effort). Disable it with `VOX_DISABLE_CUDA_ATTN_V4=1`.
-- `VOX_CUDA_FAST=1` also enables the full CUDA streaming pipeline by default (keeps adapter embeddings on-device and builds step embeddings on GPU). Disable it with `VOX_CUDA_PIPELINE_FULL=0` (or `VOX_DISABLE_CUDA_PIPELINE_FULL=1`).
-- `VOX_CUDA_FAST=1` also enables cuBLASLt autotune for the `M=1` decoder GEMMs (best-effort). Disable it with `VOX_DISABLE_CUBLASLT_AUTOTUNE=1`.
-- `VOX_CUDA_FAST=1` also enables a cuBLASLt “transpose-B view” for `M=1` decoder GEMMs (best-effort). Disable it with `VOX_DISABLE_CUBLASLT_TRANSPOSE_B=1` (or force it with `VOX_CUDA_CUBLASLT_TRANSPOSE_B=0/1`).
-- `VOX_CUDA_CUBLASLT_MAX_WS_MB=auto|<MB>` controls the *max* cuBLASLt workspace allowed for heuristic selection (can unlock faster `M=1` kernels at the cost of some persistent VRAM). Default is modest; `VOX_CUDA_FAST=1` biases it higher automatically.
+- Default fast mode also enables the chunked attention v4 path as a fallback when v5 is unavailable/disabled (fused KV append into the v3 partial kernel, best-effort). Disable it with `VOX_DISABLE_CUDA_ATTN_V4=1`.
+- Default fast mode also enables the full CUDA streaming pipeline by default (keeps adapter embeddings on-device and builds step embeddings on GPU). Disable it with `VOX_CUDA_PIPELINE_FULL=0` (or `VOX_DISABLE_CUDA_PIPELINE_FULL=1`).
+- Default fast mode also enables cuBLASLt autotune for the `M=1` decoder GEMMs (best-effort). Disable it with `VOX_DISABLE_CUBLASLT_AUTOTUNE=1`.
+- Default fast mode also enables a cuBLASLt “transpose-B view” for `M=1` decoder GEMMs (best-effort). Disable it with `VOX_DISABLE_CUBLASLT_TRANSPOSE_B=1` (or force it with `VOX_CUDA_CUBLASLT_TRANSPOSE_B=0/1`).
+- `VOX_CUDA_CUBLASLT_MAX_WS_MB=auto|<MB>` controls the *max* cuBLASLt workspace allowed for heuristic selection (can unlock faster `M=1` kernels at the cost of some persistent VRAM). Default is modest; fast mode biases it higher automatically.
+- Override fast mode directly with `VOX_CUDA_FAST=0/1`, or disable with `VOX_DISABLE_CUDA_FAST=1`.
 - `VOX_CUDA_LT_COMPUTE=32F_FAST_16BF` (or similar) opts into alternate cuBLASLt compute modes for BF16 GEMMs (default: `32F`). This may change outputs slightly; use `./scripts/accuracy_regression.sh` to validate.
 
 To run the extra CUDA benchmark variants (graphs/v3/merged/etc):

--- a/voxtral_cuda.c
+++ b/voxtral_cuda.c
@@ -313,10 +313,16 @@ static int attn_v3_disabled(void) {
 }
 
 static int cuda_fast_enabled(void) {
+    /* Default-on for this CUDA backend because long-stream decoder throughput
+     * regresses significantly without the fast-path stack (graphs/merged GEMMs/
+     * fused logits/attention upgrades). Keep explicit opt-out envs for safety. */
     static int cached = -1;
     if (cached != -1) return cached;
+    const char *disable = getenv("VOX_DISABLE_CUDA_FAST");
+    if (disable && disable[0] && disable[0] != '0') { cached = 0; return cached; }
     const char *env = getenv("VOX_CUDA_FAST");
-    cached = (env && env[0] && env[0] != '0');
+    if (env) { cached = (env[0] && env[0] != '0'); return cached; }
+    cached = 1;
     return cached;
 }
 


### PR DESCRIPTION
This PR keeps the original intent from @taf2 and updates it to be merge-ready on current `main`.

Credit
- Original work and findings: @taf2
- This cleanup rebases/splits the branch so only the two net-new changes remain.

What this PR now contains
1. `Makefile`: CUDA build compatibility + architecture detection
- Auto-detect `CUDA_ARCH` from `nvidia-smi` (fallback to `sm_86`).
- Add `CUDA_NVCCFLAGS` and pass `-U_GNU_SOURCE` to `nvcc` to avoid newer-glibc macro collisions.

2. CUDA runtime default behavior
- Make `VOX_CUDA_FAST` default-on for CUDA builds to stabilize long-stream throughput.
- Add explicit opt-out: `VOX_DISABLE_CUDA_FAST=1`.
- Keep explicit override: `VOX_CUDA_FAST=0/1`.

3. Docs alignment
- Update README CUDA tuning section to reflect default-fast behavior and env overrides.

Why cleanup was needed
- The original branch had a long historical stack (37 commits) and had become dirty/conflicted against current `main`.
- This rewrite preserves @taf2’s intended fixes while minimizing review surface and merge risk.

Validation performed
- `make -n cuda` dry-run (Makefile parse + command generation)
- `make info`, `make help`
- conflict-marker and patch-integrity checks

Notes
- Full CUDA runtime transcription benchmarking is environment-dependent and should be run in CI/local GPU validation after merge.